### PR TITLE
Remove browser test

### DIFF
--- a/source/demos/03_EnhancedWorldDemo/debug.html
+++ b/source/demos/03_EnhancedWorldDemo/debug.html
@@ -40,23 +40,6 @@
         
          function main()
          {
-            var bMayRun = false;
-            if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent))
-            {
-               var ffversion=new Number(RegExp.$1)
-               if (ffversion>=4)
-               {
-                  bMayRun = true;
-               }
-            }
-            
-            if (!bMayRun)
-            {
-               document.write("<h3>Sorry your browser is now supported</h3> This alpha preview only runs on Firefox 4.");
-               alert("Sorry, the alpha preview requires Firefox 4.x. Later versions will support more browsers.");
-               return;
-            }
-      
             // (1) create an OpenWebGlobe context using canvas
             g_context = ogCreateContextFromCanvas("canvas", true);
    

--- a/source/demos/03_EnhancedWorldDemo/demo.html
+++ b/source/demos/03_EnhancedWorldDemo/demo.html
@@ -38,23 +38,6 @@
         
          function main()
          {
-            var bMayRun = false;
-            if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent))
-            {
-               var ffversion=new Number(RegExp.$1)
-               if (ffversion>=4)
-               {
-                  bMayRun = true;
-               }
-            }
-            
-            if (!bMayRun)
-            {
-               document.write("<h3>Sorry your browser is now supported</h3> This alpha preview only runs on Firefox 4.");
-               alert("Sorry, the alpha preview requires Firefox 4.x. Later versions will support more browsers.");
-               return;
-            }
-      
             // (1) create an OpenWebGlobe context using canvas
             g_context = ogCreateContextFromCanvas("canvas", true);
    


### PR DESCRIPTION
Firefox 5.0 does not allow cross-domain textures, see
  http://hacks.mozilla.org/2011/06/cross-domain-webgl-textures-disabled-in-firefox-5/
This prevents OpenWebGlobe from loading tiles from other servers.

Chrome does not yet prohibit cross-domain textures, and seems to work perfectly.

The attached patch removes the code that prevents OWG from running on Firefox and so allows developers to use Chrome :-)

Regards,
Tom
