### PR TITLE
Add metadata to invoke Chrome Frame

### DIFF
--- a/source/demos/01_HelloWorld/demo.html
+++ b/source/demos/01_HelloWorld/demo.html
@@ -28,6 +28,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="X-UA-Compatible" content="chrome=1">
 
 <script type="text/javascript" src="../../../external/closure-library/closure/goog/base.js"></script>
 <script type="text/javascript" src="../../../compiled/deps.js"></script>

--- a/source/demos/01_HelloWorld/optimizedDemo.html
+++ b/source/demos/01_HelloWorld/optimizedDemo.html
@@ -28,6 +28,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="X-UA-Compatible" content="chrome=1">
 
 <script type="text/javascript" src="../../../compiled/owg-optimized.js"></script>
 <script type="text/javascript">

--- a/source/demos/03_WorldDemo/demo.html
+++ b/source/demos/03_WorldDemo/demo.html
@@ -4,6 +4,7 @@
 <!DOCTYPE html>
 <html>
       <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+      <meta http-equiv="X-UA-Compatible" content="chrome=1">
          <!-- >
             <script type="text/javascript" src="http://benvanik.github.com/WebGL-Inspector/core/embed.js"></script>  
          -->

--- a/source/demos/04_SwisstopoDemo/index.html
+++ b/source/demos/04_SwisstopoDemo/index.html
@@ -23,6 +23,7 @@
 <!DOCTYPE html>
 <html>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="X-UA-Compatible" content="chrome=1">
 
 <link rel="stylesheet" type="text/css" href="styles/styles.css">
 


### PR DESCRIPTION
This patch adds http-equiv metadata to activate Chrome Frame if it is installed in the user's browser. This effectively gives fake Internet Explorer support.

Regards,
Tom
