### PR TITLE
Add define to choose navigation mode

### DIFF
--- a/source/core/scenegraph.js
+++ b/source/core/scenegraph.js
@@ -33,6 +33,13 @@ goog.require('owg.RenderNode');
 goog.require('owg.TraversalState');
 goog.require('owg.mat4');
 
+
+/**
+ * @define {string} Navigation mode ('flight' or 'globe').
+ */
+owg.NAVIGATION_MODE = 'flight';
+
+
 //------------------------------------------------------------------------------
 /**
  * Scenegraph Class.
@@ -45,7 +52,14 @@ function SceneGraph(engine)
    /** @type {engine3d} */
    this.engine = engine;         // Render Engine
    
-   this.navigation = new NavigationNode(); /*new GlobeNavigationNode();*/
+   if (owg.NAVIGATION_MODE == 'globe')
+   {
+     this.navigation = new GlobeNavigationNode();
+   }
+   else
+   {
+     this.navigation = new NavigationNode();
+   }
    this.navigation.SetEngine(engine);
    this.navigation.InitNode();
    


### PR DESCRIPTION
The attached patch allows the navigation mode to be chosen at compile time (if using the compiled version) or run time (if using the uncompiled version).

To select globe navigation in compiled mode, add --compiler_flags=--define=owg.NAVIGATION_MODE=globe when you call closurebuilder.py.

To select globe navigation in uncompiled mode, add
  owg.NAVIGATION_MODE = 'globe';
to your JavaScript, after calling goog.require('owg.OpenWebGlobe') but before calling any OpenWebGlobe functions.
