### PR TITLE
Fixed bug in ogRemoveElevationLayer().

### DIFF
--- a/source/core/og.js
+++ b/source/core/og.js
@@ -1708,7 +1708,7 @@ function ogRemoveElevationLayer(layer_id)
    var layer = _GetObjectFromId(layer_id);
    if (layer && layer.type == OG_OBJECT_ELEVATIONLAYER)
    {
-      layer.RemoveImageLayer();
+      layer.RemoveElevationLayer();
       layer.UnregisterObject();
    }
 }


### PR DESCRIPTION
Hi,

i found a bug in ogRemoveElevationLayer().
After checking if the layer exists and if it's an elevationlayer layer.RemoveImageLayer() is called.
I changed it to layer.RemoveElevationLayer().

Kind regards
Kai
