### PR TITLE
Option shownavigation=true/false that can be passed to ogCreateScene 

### DIFF
--- a/source/core/og.js
+++ b/source/core/og.js
@@ -1487,6 +1487,7 @@ function ogCreateWorld(scene_id)
    {
       var worldoptions = {};
       worldoptions["scenetype"] = scene.scenetype;
+      worldoptions["shownavigation"] = scene.shownavigation;
       var world = _CreateObject(OG_OBJECT_WORLD, scene, worldoptions);
       scene.world = world;
 

--- a/source/core/og/ogScene.js
+++ b/source/core/og/ogScene.js
@@ -52,6 +52,8 @@ function ogScene()
    this.scenetype = OG_SCENE_3D_ELLIPSOID_WGS84;
    /** @type {boolean} */
    this.rendertotexture = true;
+   /** @type {boolean} */
+   this.shownavigation = true;
 }
 //------------------------------------------------------------------------------
 ogScene.prototype = new ogObject();
@@ -77,6 +79,11 @@ ogScene.prototype.ParseOptions = function(options)
    if (goog.isDef(options["rendertotexture"]))
    {
       this.rendertotexture = options["rendertotexture"];
+   }
+   
+   if (goog.isDef(options["shownavigation"])) 
+   {
+   	this.shownavigation = options["shownavigation"];
    }
 }
 //------------------------------------------------------------------------------

--- a/source/core/og/ogWorld.js
+++ b/source/core/og/ogWorld.js
@@ -66,7 +66,8 @@ ogWorld.prototype.ParseOptions = function(options)
       /** @type {Object} */
       var sceneoptions =   // more options will be available in future
       {
-         "rendertotexture" : scene.rendertotexture
+         "rendertotexture" : scene.rendertotexture,
+         "shownavigation" : scene.shownavigation
       };
 
       if (options["scenetype"] == OG_SCENE_3D_ELLIPSOID_WGS84)

--- a/source/core/scenegraph.js
+++ b/source/core/scenegraph.js
@@ -52,7 +52,16 @@ function SceneGraph(engine, options)
    // Access Nodes:
    this.nodeCamera = new CameraNode();                      // Camera Node (for projection matrix)
    this.nodeRenderObject = new RenderObjectNode(options);   // Render Object Node (render openglobe objects, e.g. the virtual globe)
-   this.nodeLogos = new LogosNode();
+      
+   if (!goog.isDef(options["shownavigation"])) 
+   {
+      options["shownavigation"] = true;
+   }
+      
+   if (options["shownavigation"]) 
+   {
+      this.nodeLogos = new LogosNode();
+   }
    
    this.nodeCamera.SetEngine(engine);
    this.nodeCamera.InitNode();
@@ -60,8 +69,11 @@ function SceneGraph(engine, options)
    this.nodeRenderObject.SetEngine(engine);
    this.nodeRenderObject.InitNode();
 
-   this.nodeLogos.SetEngine(engine);
-   this.nodeLogos.InitNode();
+   if (this.nodeLogos)
+   {
+      this.nodeLogos.SetEngine(engine);
+      this.nodeLogos.InitNode();
+   }
    
    this.traversalstate = new TraversalState();
 
@@ -81,7 +93,10 @@ SceneGraph.prototype.Tick = function(nMSeconds)
    this.nodeNavigation.OnTick(nMSeconds);
    this.nodeCamera.OnTick(nMSeconds);
    this.nodeRenderObject.OnTick(nMSeconds);
-   this.nodeLogos.OnTick(nMSeconds);
+   if (this.nodeLogos)
+   {
+      this.nodeLogos.OnTick(nMSeconds);
+   }
 };
 //------------------------------------------------------------------------------
 /**
@@ -96,7 +111,11 @@ SceneGraph.prototype.Traverse = function()
    this.nodeNavigation.OnTraverse(this.traversalstate);
    this.nodeCamera.OnTraverse(this.traversalstate);
    this.nodeRenderObject.OnTraverse(this.traversalstate);
-   this.nodeLogos.OnTraverse(this.traversalstate);
+      
+   if (this.nodeLogos)
+   {
+      this.nodeLogos.OnTraverse(this.traversalstate);
+   }
    
    this.traversalstate.PopModel();
    this.traversalstate.PopView();
@@ -119,9 +138,12 @@ SceneGraph.prototype.Render = function()
    // Render globe, poi, geometry, billboards, images on terrain
    this.nodeRenderObject.OnChangeState();
    this.nodeRenderObject.OnRender();
-       
-   this.nodeLogos.OnChangeState();
-   this.nodeLogos.OnRender();        
+   
+   if (this.nodeLogos) 
+   {    
+      this.nodeLogos.OnChangeState();
+      this.nodeLogos.OnRender();        
+	}
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
... set to false no LogosNode will be created and updated.
I need this, because I'm developing a custom NavigationNode without any visible controls - a IsometricCamera that switches to FirstPerson on doubleclick. 

Is almost identical to GlobeNavigation, I can open a separate pull if needed.
