### PR TITLE
Pass current engine state into OnRender function

### DIFF
--- a/source/core/og/ogContext.js
+++ b/source/core/og/ogContext.js
@@ -72,7 +72,39 @@ function _ctx_callback_render(engine)
    
    if (context.cbfRender)
    {
-      context.cbfRender(context.id);
+      var visibleTiles = [];
+
+      if (engine.scene.nodeRenderObject &&
+            engine.scene.nodeRenderObject.globerenderer &&
+            engine.scene.nodeRenderObject.globerenderer.lstFrustum) 
+      {
+         for (var i=0;i<engine.scene.nodeRenderObject.globerenderer.lstFrustum.length;i++) 
+         {
+            var tile = engine.scene.nodeRenderObject.globerenderer.lstFrustum[i];
+            visibleTiles[visibleTiles.length] = 
+            {
+               "quadcode": tile.quadcode,
+               "sw": [tile.longitude0, tile.latitude0],
+               "ne": [tile.longitude1, tile.latitude1],
+               "available": tile.available
+            };
+         }   
+      }
+      
+      context.cbfRender(context.id, 
+         {
+            "gl": engine.gl,
+            "cameraVec": engine.scene.nodeRenderObject.camera.ToFloat32Array(),
+            "eyeVec": engine.scene.nodeNavigation._vEye.ToFloat32Array(),
+            "vMatrix": engine.matView.ToFloat32Array(),
+            "pMatrix": engine.matProjection.ToFloat32Array(),
+            "viewPort": {
+               "width": engine.width,
+               "height": engine.height
+            },
+            "visibleTiles": visibleTiles
+         }
+      );
    }
 }
 //------------------------------------------------------------------------------


### PR DESCRIPTION
I'm using this for plugging in my custom renderer for rendering animated water surfaces and billboard forests. 
With some hacking it should also pave the way for integrating other 3rd party WebGL libs like three.js or spiderGL. Although some passing of the GL context, mvp matrices and camera vectors must be done.
