### PR TITLE
Update mercatorquadtree.js

### DIFF
--- a/source/core/mercatorquadtree.js
+++ b/source/core/mercatorquadtree.js
@@ -183,17 +183,17 @@ MercatorQuadtree.prototype.QuadKeyToWGS84 = function(quadcode, coords)
    var maxpixelY=(1.00-mercator[3])*256*Math.pow(2,lod);  
    var x = (Math.min(Math.max(minpixelX, 0), mapSize - 1) / mapSize) - 0.5;
    var y = 0.5 - (Math.min(Math.max(minpixelY, 0), mapSize - 1) / mapSize);
-   var minx = 90.0 - 360.0 * Math.atan(Math.exp(-y * 2.0 * Math.PI)) / Math.PI;
-   var miny = 360.0000 * x;
+   var miny = 90.0 - 360.0 * Math.atan(Math.exp(-y * 2.0 * Math.PI)) / Math.PI;
+   var minx = 360.0000 * x;
 
-   x = (Math.min(Math.max(minpixelX, 0), mapSize - 1) / mapSize) - 0.5;
-   y = 0.5 - (Math.min(Math.max(minpixelY, 0), mapSize - 1) / mapSize);
-   var maxx = 90.0 - 360.0 * Math.atan(Math.exp(-y * 2.0 * Math.PI)) / Math.PI;
-   var maxy = 360.0000 * x;
-    coords[0]=minx;
-    coords[1]=miny;
-    coords[2]=maxx;
-    coords[3]=maxy;
+   x = (Math.min(Math.max(maxpixelX, 0), mapSize - 1) / mapSize) - 0.5;
+   y = 0.5 - (Math.min(Math.max(maxpixelY, 0), mapSize - 1) / mapSize);
+   var maxy = 90.0 - 360.0 * Math.atan(Math.exp(-y * 2.0 * Math.PI)) / Math.PI;
+   var maxx = 360.0000 * x;
+   coords[0]=minx;		//swap(y0,y1) coordinates for pixel based coordinates.
+   coords[1]=maxy;
+   coords[2]=maxx;
+   coords[3]=miny;
 
 }
 //------------------------------------------------------------------------------


### PR DESCRIPTION
A little bug fix to QuadKeyToWGS84 in computing tile coordinates.
