### PR TITLE
Explicitly request stencil buffer on context creation

### DIFF
--- a/source/core/engine3d.js
+++ b/source/core/engine3d.js
@@ -369,7 +369,7 @@ var create3DContext = function (canvas)
    {
       try
       {
-         context = canvas.getContext(names[ii], { antialias:false });
+         context = canvas.getContext(names[ii], { antialias: false, stencil: true });
       }
       catch (e)
       {


### PR DESCRIPTION
Vector rendering did not work in chrome, because it requires the stencil buffer to be explicitly requested.
